### PR TITLE
Unknown card possibility tracking

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -31,3 +31,26 @@
   flex-direction: column;
   align-items: center;
 }
+
+.card.is-selected {
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+}
+
+.column.full-tag {
+  padding: 0.25rem;
+  .tag {
+    width: 100%;
+  }
+}
+
+.card.is-hoverable {
+  vertical-align: middle;
+  transform: perspective(1px) translateZ(0);
+  transition-duration: 0.3s;
+  transition-property: box-shadow, transform;
+}
+
+.card.is-hoverable:hover {
+  box-shadow: 0 10px 10px -10px rgba(0, 0, 0, 0.5);
+  transform: scale(1.05);
+}

--- a/src/ts/components/AllianceSelect.tsx
+++ b/src/ts/components/AllianceSelect.tsx
@@ -2,13 +2,13 @@ import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { house_name_t, ALL_HOUSE_NAMES } from "ts/houses";
 import { house_set_ally } from "ts/state/actions";
-import { root_state } from "ts/state/reducers";
+import { root_state_t } from "ts/state/reducers";
 
 const AllianceSelect: React.FC<{
   house: house_name_t;
   ally: house_name_t | null;
 }> = props => {
-  const houses_state = useSelector((state: root_state) => state.houses);
+  const houses_state = useSelector((state: root_state_t) => state.game.current.houses);
   const dispatch = useDispatch();
 
   const possible_allies = [

--- a/src/ts/components/ExpandableCardList.tsx
+++ b/src/ts/components/ExpandableCardList.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { treachery_card_t } from "ts/treachery_card";
+import TreacheryCard, { treachery_card_colours } from "ts/components/TreacheryCard";
+
+const ExpandableCardList: React.FC<{ cards: Array<treachery_card_t> }> = ({ cards }) => {
+  const [expand, set_expand] = React.useState(false);
+
+  return (
+    <div className="box">
+      <div className="columns is-vcentered">
+        <div className="column">
+          <div className="tags">
+            {!expand &&
+              cards.map((card, index) => {
+                const colour = treachery_card_colours[card.kind].bg;
+                let text: string = card.kind;
+                switch (card.kind) {
+                  case "Weapon":
+                  case "Defense":
+                  case "Special": {
+                    text = card.type;
+                    break;
+                  }
+                }
+                return (
+                  <span className={"tag is-medium is-" + colour} key={card.id}>
+                    {text}
+                  </span>
+                );
+              })}
+          </div>
+        </div>
+        <div className="column is-narrow">
+          <button
+            className="button is-fullwidth is-link is-outlined"
+            onClick={() => set_expand(!expand)}
+          >
+            <span className="icon">
+              <i className={"fas fa-angle-" + (expand ? "up" : "down")} />
+            </span>
+            <span>View</span>
+          </button>
+        </div>
+      </div>
+      {expand && (
+        <>
+          <hr />
+          <div className="columns is-multiline">
+            {cards.map(card => (
+              <div className="column is-half is-one-quarter-desktop" key={card.id}>
+                <TreacheryCard card={card} />
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ExpandableCardList;

--- a/src/ts/components/GameContainer.tsx
+++ b/src/ts/components/GameContainer.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { useSelector } from "react-redux";
 import GameOverview from "ts/components/GameOverview";
 import NewGame from "ts/components/NewGame";
-import { root_state } from "ts/state/reducers";
+import { root_state_t } from "ts/state/reducers";
 
 const GameContainer: React.FC = () => {
-  const state = useSelector((state: root_state) => {
+  const state = useSelector((state: root_state_t) => {
     return state.game;
   });
 

--- a/src/ts/components/GameOverview.tsx
+++ b/src/ts/components/GameOverview.tsx
@@ -1,29 +1,54 @@
 import * as React from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { root_state } from "ts/state/reducers";
+import { root_state_t } from "ts/state/reducers";
 import { house_name_t, ALL_HOUSE_NAMES } from "ts/houses";
-import { show_reset_game_modal } from "ts/state/actions";
+import { show_reset_game_modal, undo_action } from "ts/state/actions";
 import { house_state_t } from "ts/state/types";
-import AddCardPage from "ts/components/Modals/AddCardModal";
-import ConfirmResetPage from "ts/components/Modals/ConfirmResetModal";
+import AddCardModal from "ts/components/Modals/AddCardModal";
+import ConfirmResetModal from "ts/components/Modals/ConfirmResetModal";
 import HouseTile from "ts/components/HouseTile";
+import DiscardUnknownModal from "ts/components/Modals/DiscardUnknownModal";
+import { treachery_card_t, card_sort } from "ts/treachery_card";
+import ExpandableCardList from "ts/components/ExpandableCardList";
 
 const GameOverview: React.FC = () => {
-  const state = useSelector((state: root_state) => ({
-    houses: state.houses,
-    view: state.view,
-  }));
+  const { houses, view, deck_cards, discarded_cards, cards_left_in_deck, can_undo } = useSelector(
+    (state: root_state_t) => {
+      let discarded_cards: Array<treachery_card_t> = [];
+      for (let i = 0; i < state.game.current.decks.length; i++) {
+        if (i === state.game.current.draw_deck_index) {
+          continue;
+        }
+        discarded_cards = discarded_cards.concat(state.game.current.decks[i].cards);
+      }
+      discarded_cards.sort(card_sort);
+
+      const draw_deck = state.game.current.decks[state.game.current.draw_deck_index];
+      return {
+        houses: state.game.current.houses,
+        view: state.view,
+        deck_cards: draw_deck.cards,
+        discarded_cards,
+        cards_left_in_deck: draw_deck.cards.length - draw_deck.num_unknowns,
+        can_undo: state.game.history.length > 0,
+      };
+    }
+  );
   const dispatch = useDispatch();
 
-  const house = state.houses[state.view.house_name as house_name_t] as house_state_t;
+  const house = houses[view.house_name as house_name_t] as house_state_t;
   let modal: JSX.Element | null;
-  switch (state.view.active_modal) {
+  switch (view.active_modal) {
     case "add_card": {
-      modal = <AddCardPage house={house.name} />;
+      modal = <AddCardModal house={house.name} />;
       break;
     }
     case "reset_game": {
-      modal = <ConfirmResetPage />;
+      modal = <ConfirmResetModal />;
+      break;
+    }
+    case "discard_unknown": {
+      modal = <DiscardUnknownModal house={house.name} />;
       break;
     }
     default: {
@@ -33,16 +58,48 @@ const GameOverview: React.FC = () => {
   }
   return (
     <>
+      <div className="container">
+        <nav className="navbar">
+          <div className="navbar-end">
+            <div className="navbar-item">
+              <div className="buttons">
+                <button
+                  className="button is-info"
+                  onClick={() => dispatch(undo_action())}
+                  disabled={!can_undo}
+                >
+                  <span className="icon">
+                    <i className="fas fa-undo"></i>
+                  </span>
+                  <span>Undo</span>
+                </button>
+                <button
+                  className="button"
+                  onClick={() => {
+                    dispatch(show_reset_game_modal());
+                  }}
+                >
+                  <span className="icon">
+                    <i className="fas fa-power-off"></i>
+                  </span>
+                  <span>Reset game</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </nav>
+      </div>
       <section className="section">
         <div className="container">
+          <h2 className="title">Factions</h2>
           <div className="columns is-multiline">
             {ALL_HOUSE_NAMES.map(name => {
-              const house = state.houses[name];
+              const house = houses[name];
               if (!house.active) {
                 return null;
               }
               return (
-                <div className="column is-full-tablet is-half-desktop" key={name}>
+                <div className="column is-full-tablet is-half-widescreen" key={name}>
                   <HouseTile house={name} />
                 </div>
               );
@@ -50,18 +107,18 @@ const GameOverview: React.FC = () => {
           </div>
         </div>
       </section>
+      <hr />
       <section className="section">
         <div className="container">
-          <div className="buttons is-centered">
-            <button
-              className="button is-secondary"
-              onClick={() => {
-                dispatch(show_reset_game_modal());
-              }}
-            >
-              Reset game
-            </button>
-          </div>
+          <h2 className="title">Cards in deck</h2>
+          <h3 className="subtitle">{cards_left_in_deck} cards remaining before a shuffle</h3>
+          <ExpandableCardList cards={deck_cards} />
+        </div>
+      </section>
+      <section className="section">
+        <div className="container">
+          <h2 className="title">Discarded cards</h2>
+          <ExpandableCardList cards={discarded_cards} />
         </div>
       </section>
       {modal}

--- a/src/ts/components/HouseBanner.tsx
+++ b/src/ts/components/HouseBanner.tsx
@@ -9,7 +9,7 @@ import { ReactComponent as HarkonnenIcon } from "assets/houses/harkonnen.svg";
 import { ReactComponent as GuildIcon } from "assets/houses/spacing_guild.svg";
 import { ReactComponent as NoneIcon } from "assets/houses/none.svg";
 import { useSelector, useDispatch } from "react-redux";
-import { root_state } from "ts/state/reducers";
+import { root_state_t } from "ts/state/reducers";
 import { house_set_ally } from "ts/state/actions";
 
 export const icon_map = {
@@ -36,12 +36,14 @@ export const HouseNameWithIcon: React.FC<{ house: house_name_t }> = ({ house }) 
 
 const HouseBanner: React.FC<{ house: house_name_t }> = props => {
   const dispatch = useDispatch();
-  const { ally, possibleAllies } = useSelector((state: root_state) => {
+  const { ally, possibleAllies } = useSelector((state: root_state_t) => {
     return {
-      ally: state.houses[props.house].ally,
+      ally: state.game.current.houses[props.house].ally,
       possibleAllies: [
         null,
-        ...ALL_HOUSE_NAMES.filter(name => name !== props.house && state.houses[name].active),
+        ...ALL_HOUSE_NAMES.filter(
+          name => name !== props.house && state.game.current.houses[name].active
+        ),
       ],
     };
   });

--- a/src/ts/components/HouseTile.tsx
+++ b/src/ts/components/HouseTile.tsx
@@ -3,14 +3,14 @@ import { useSelector } from "react-redux";
 import { house_name_t } from "ts/houses";
 import HouseBanner from "ts/components/HouseBanner";
 import ViewCards from "ts/components/ViewCards";
-import { root_state } from "ts/state/reducers";
+import { root_state_t } from "ts/state/reducers";
 
 export interface HouseTileProps {
   house: house_name_t;
 }
 
 const HouseTile: React.FC<HouseTileProps> = props => {
-  const houseState = useSelector((state: root_state) => state.houses[props.house]);
+  const house_state = useSelector((state: root_state_t) => state.game.current.houses[props.house]);
   return (
     <>
       <div className="box">
@@ -20,7 +20,7 @@ const HouseTile: React.FC<HouseTileProps> = props => {
           </div>
         </div>
         <hr />
-        <ViewCards house={props.house} cards={houseState.cards} />
+        <ViewCards {...house_state} />
       </div>
     </>
   );

--- a/src/ts/components/Modals/AddCardModal.tsx
+++ b/src/ts/components/Modals/AddCardModal.tsx
@@ -2,58 +2,50 @@ import * as React from "react";
 import { house_name_t } from "ts/houses";
 import TreacheryCard from "ts/components/TreacheryCard";
 import { useDispatch, useSelector } from "react-redux";
-import { house_add_card, close_modal } from "ts/state/actions";
+import { close_modal, house_add_card, house_add_unknown } from "ts/state/actions";
 import Modal from "ts/components/Modals/Modal";
 import { HouseNameWithIcon } from "ts/components/HouseBanner";
-import { root_state } from "ts/state/reducers";
-import { treachery_card_t } from "ts/treachery_card";
-
-const TreacheryCardWrapper: React.FC<{
-  card: treachery_card_t;
-  num?: number;
-  house: house_name_t;
-}> = ({ house, card, num }) => {
-  const dispatch = useDispatch();
-  return (
-    <div
-      className="column is-one-quarter-widescreen is-half"
-      onClick={() => {
-        dispatch(house_add_card(house, card));
-        dispatch(close_modal());
-      }}
-      style={{ cursor: "pointer" }}
-    >
-      <TreacheryCard card={card} num={num} />
-    </div>
-  );
-};
+import { root_state_t } from "ts/state/reducers";
+import UnknownCard from "ts/components/UnknownCard";
 
 const AddCardPage: React.FC<{ house: house_name_t }> = props => {
   const dispatch = useDispatch();
-  const card_pool = useSelector((state: root_state) => {
-    return state.game.treachery_card_pool;
+  const [draw_deck, draw_deck_index] = useSelector((state: root_state_t) => {
+    return [
+      state.game.current.decks[state.game.current.draw_deck_index],
+      state.game.current.draw_deck_index,
+    ];
   });
+
   const close = () => dispatch(close_modal());
   const header = (
     <div className="columns is-mobile is-vcentered">
       <HouseNameWithIcon house={props.house} />
     </div>
   );
-
   return (
     <Modal close={close} header={header} isFull>
       <div className="columns is-multiline">
-        {card_pool.map((card, index) => {
-          if (card.num === 0) {
-            return null;
-          }
+        <div className="column is-one-quarter-widescreen is-half">
+          <UnknownCard
+            deck_index={draw_deck_index}
+            onClick={() => {
+              dispatch(house_add_unknown(props.house));
+              dispatch(close_modal());
+            }}
+          />
+        </div>
+        {draw_deck.cards.map(card => {
           return (
-            <TreacheryCardWrapper
-              card={card.card}
-              num={card.num}
-              house={props.house}
-              key={"card-" + index}
-            />
+            <div className="column is-one-quarter-widescreen is-half" key={card.id}>
+              <TreacheryCard
+                card={card}
+                onClick={() => {
+                  dispatch(house_add_card(props.house, card));
+                  dispatch(close_modal());
+                }}
+              />
+            </div>
           );
         })}
       </div>

--- a/src/ts/components/Modals/ConfirmResetModal.tsx
+++ b/src/ts/components/Modals/ConfirmResetModal.tsx
@@ -15,7 +15,7 @@ const ConfirmResetPage: React.FC = () => {
   const header = <h1>Reset the game</h1>;
 
   return (
-    <Modal header={header} close={close} buttons={[confirm_button]}>
+    <Modal header={header} close={close} buttons={confirm_button}>
       <p className="subtitle has-text-centered"> Are you sure?</p>
     </Modal>
   );

--- a/src/ts/components/Modals/DiscardUnknownModal.tsx
+++ b/src/ts/components/Modals/DiscardUnknownModal.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Modal from "ts/components/Modals/Modal";
+import { treachery_card_t } from "ts/treachery_card";
+import { house_name_t } from "ts/houses";
+import { useDispatch, useSelector } from "react-redux";
+import { close_modal, house_remove_unknown } from "ts/state/actions";
+import { root_state_t } from "ts/state/reducers";
+import TreacheryCard from "ts/components/TreacheryCard";
+
+const DiscardUnknownModal: React.FC<{ house: house_name_t }> = ({ house }) => {
+  const dispatch = useDispatch();
+  const [unknown_cards, decks] = useSelector((root_state: root_state_t) => {
+    const unknown_cards = root_state.game.current.houses[house].unknown_cards;
+    const decks = root_state.game.current.decks;
+    return [unknown_cards, decks];
+  });
+
+  // get a list of the possible decks this player has unknown cards in
+  const possible_deck_ids = unknown_cards
+    .map(c => c.deck_index)
+    .filter((a, b, arr) => arr.indexOf(a) === b);
+
+  const possible_cards: Array<{ card: treachery_card_t; deck_index: number }> = [];
+
+  for (let i = 0; i < possible_deck_ids.length; i++) {
+    const deck_index = possible_deck_ids[i];
+    const deck = decks[possible_deck_ids[i]];
+    deck.cards.forEach(card => possible_cards.push({ card, deck_index }));
+  }
+
+  return (
+    <Modal header="Which card was discarded?" close={() => dispatch(close_modal())} isFull>
+      <div className="columns is-multiline">
+        {possible_cards.map((possible, index) => {
+          return (
+            <div className="column is-half is-one-quarter-widescreen" key={"card-" + index}>
+              <TreacheryCard
+                card={possible.card}
+                onClick={() => {
+                  const unknown_index = unknown_cards.findIndex(
+                    un => un.deck_index === possible.deck_index
+                  );
+                  dispatch(house_remove_unknown(house, unknown_index, possible.card.id));
+                  dispatch(close_modal());
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </Modal>
+  );
+};
+
+export default DiscardUnknownModal;

--- a/src/ts/components/NewGame.tsx
+++ b/src/ts/components/NewGame.tsx
@@ -49,8 +49,29 @@ export default () => {
     <>
       <section className="section">
         <div className="container">
-          <p className="title is-1">New game</p>
-          <p className="subtitle is-5">Select which houses are present in the game</p>
+          <div className="columns is-vcentered">
+            <div className="column">
+              <p className="title is-1">New game</p>
+              <p className="subtitle is-5">Select which houses are present in the game</p>
+            </div>
+            <div className="column is-narrow">
+              <button
+                className="button is-success is-large"
+                disabled={!allow_start}
+                onClick={() => {
+                  if (allow_start) {
+                    dispatch(start_game(state));
+                    dispatch(close_modal());
+                  }
+                }}
+              >
+                <span className="icon">
+                  <i className="fas fa-play"></i>
+                </span>
+                <span>Start game</span>
+              </button>
+            </div>
+          </div>
         </div>
       </section>
       <section className="section">
@@ -68,22 +89,6 @@ export default () => {
               />
             ))}
           </div>
-        </div>
-      </section>
-      <section className="section">
-        <div className="container">
-          <button
-            className="button is-primary is-fullwidth"
-            disabled={!allow_start}
-            onClick={() => {
-              if (allow_start) {
-                dispatch(start_game(state));
-                dispatch(close_modal());
-              }
-            }}
-          >
-            Start game
-          </button>
         </div>
       </section>
     </>

--- a/src/ts/components/TreacheryCard.tsx
+++ b/src/ts/components/TreacheryCard.tsx
@@ -19,7 +19,7 @@ export const treachery_card_colours = {
   Unknown: { text: "white", bg: "dark" },
 } as const;
 
-const icons = {
+export const treachery_card_icons = {
   Shield: <ShieldIcon width={32} />,
   Snooper: <SnooperIcon width={32} />,
   Lasgun: <LaserIcon width={32} />,
@@ -32,55 +32,57 @@ const icons = {
 
 const TreacheryCard: React.FC<{
   card: treachery_card_t;
+  onClick?: () => void;
   onDelete?: () => void;
-  num?: number;
-}> = ({ card, onDelete, num }) => {
+}> = ({ card, onClick, onDelete }) => {
   const info = treachery_card_colours[card.kind];
-  let title = "";
+  let title: string;
   let text: JSX.Element | null = null;
   let icon: JSX.Element;
   switch (card.kind) {
-    case "Unknown": {
-      title = "Unknown";
-      icon = icons["Unknown"];
-      text = card_text.Unknown;
-      break;
-    }
     case "Useless": {
-      title = "Useless";
-      icon = icons["Useless"];
+      icon = treachery_card_icons["Useless"];
       text = card_text.Useless;
+      title = card.id;
       break;
     }
     case "Special": {
-      title = "Special - " + card.type;
-      icon = icons["Special"];
+      icon = treachery_card_icons["Special"];
       text = card_text[card.type];
+      title = card.type;
       break;
     }
-    case "Weapon":
-    case "Defense": {
-      title = card.kind + " - " + card.type;
-      icon = icons[card.type];
+    case "Weapon": {
+      icon = treachery_card_icons[card.type];
       text = card_text[card.type];
+      title = card.id;
+      break;
+    }
+    case "Defense": {
+      icon = treachery_card_icons[card.type];
+      text = card_text[card.type];
+      title = card.type;
       break;
     }
   }
+  let className = "card";
+  if (onClick) {
+    className += " is-hoverable";
+  }
+
+  let style: React.CSSProperties = { height: "280px", overflowY: "auto" };
+  if (onClick) {
+    style.cursor = "pointer";
+  }
+
   return (
-    <div className="card" style={{ height: "250px", overflowY: "auto" }}>
+    <div className={className} style={style} onClick={onClick}>
       <header className={"modal-card-head has-background-" + info.bg} style={{ padding: "0 20px" }}>
         <figure className="image is-32x32 level-item">{icon}</figure>
         <div className={"card-header-title has-text-" + info.text}>{title}</div>
         {onDelete ? <button className="delete" onClick={onDelete}></button> : null}
       </header>
-      <div className="card-content is-size-7 content">
-        {num && (
-          <p>
-            <b>{num} remaining</b>
-          </p>
-        )}
-        {text}
-      </div>
+      <div className="card-content is-size-7 content">{text}</div>
     </div>
   );
 };

--- a/src/ts/components/UnknownCard.tsx
+++ b/src/ts/components/UnknownCard.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { treachery_card_t } from "ts/treachery_card";
+import { useSelector } from "react-redux";
+import { root_state_t } from "ts/state/reducers";
+import { treachery_card_colours, treachery_card_icons } from "ts/components/TreacheryCard";
+
+const ALL_STAT_TYPES = [
+  "Projectile",
+  "Poison",
+  "Lasgun",
+  "Shield",
+  "Snooper",
+  "Special",
+  "Useless",
+] as const;
+type stat_type = typeof ALL_STAT_TYPES[number];
+
+const UnknownCard: React.FC<{
+  deck_index: number;
+  onClick?: () => void;
+  onDelete?: () => void;
+}> = ({ onClick, onDelete: on_delete, deck_index: deck_id }) => {
+  const deck = useSelector((root_state: root_state_t) => {
+    return root_state.game.current.decks[deck_id];
+  });
+
+  const colours = treachery_card_colours.Unknown;
+  let counts: { [key in stat_type]: { count: number; kind: treachery_card_t["kind"] } } = {
+    Projectile: {
+      count: 0,
+      kind: "Weapon",
+    },
+    Poison: {
+      count: 0,
+      kind: "Weapon",
+    },
+    Lasgun: {
+      count: 0,
+      kind: "Weapon",
+    },
+    Shield: {
+      count: 0,
+      kind: "Defense",
+    },
+    Snooper: {
+      count: 0,
+      kind: "Defense",
+    },
+    Special: {
+      count: 0,
+      kind: "Special",
+    },
+    Useless: {
+      count: 0,
+      kind: "Useless",
+    },
+  };
+
+  for (let i = 0; i < deck.cards.length; i++) {
+    const card = deck.cards[i];
+    switch (card.kind) {
+      case "Defense":
+      case "Weapon": {
+        counts[card.type].count++;
+        break;
+      }
+      case "Special":
+      case "Useless": {
+        counts[card.kind].count++;
+        break;
+      }
+    }
+  }
+
+  let className = "card";
+  if (onClick) {
+    className += " is-hoverable";
+  }
+
+  let style: React.CSSProperties = { height: "280px", overflowY: "auto" };
+  if (onClick) {
+    style.cursor = "pointer";
+  }
+
+  return (
+    <div className={className} style={style} onClick={onClick}>
+      <header
+        className={"modal-card-head has-background-" + colours.bg}
+        style={{ padding: "0 20px" }}
+      >
+        <figure className="image is-32x32 level-item">{treachery_card_icons.Unknown}</figure>
+        <div className={"card-header-title has-text-" + colours.text}>Unknown</div>
+        {on_delete ? <button className="delete" onClick={on_delete}></button> : null}
+      </header>
+      <div className="card-content is-size-7 content">
+        <div className="columns is-multiline is-mobile">
+          {ALL_STAT_TYPES.map(key => {
+            if (!counts[key].count) {
+              return null;
+            }
+            const colour = treachery_card_colours[counts[key].kind].bg;
+            return (
+              <div className="column is-half full-tag" key={key}>
+                <span className={"tag is-medium is-" + colour}>
+                  {key} {((counts[key].count * 100.0) / deck.cards.length).toFixed(0)}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UnknownCard;

--- a/src/ts/components/card_text.tsx
+++ b/src/ts/components/card_text.tsx
@@ -2,10 +2,12 @@ import * as React from "react";
 
 const BattlePlan = <p>Play as part of your Battle Plan.</p>;
 const WinnerKeeps = <p>You may keep this card if you win this battle</p>;
+const Special = <p className="heading">Special</p>;
 
 const card_text = {
   Useless: (
     <>
+      <p className="heading">Useless</p>
       <p>Play as part of your Battle Plan, in place of a weapon, defense, or both.</p>
       <p>
         This card has no value in play, and you can discard it only by playing it in your Battle
@@ -18,6 +20,7 @@ const card_text = {
   ),
   Projectile: (
     <>
+      <p className="heading">Projectile</p>
       {BattlePlan}
       <p>
         Kills opponent's leader before battle is resolved. Opponent may protect leader with a
@@ -28,6 +31,7 @@ const card_text = {
   ),
   Poison: (
     <>
+      <p className="heading">Poison</p>
       {BattlePlan}
       <p>
         Kills opponent's leader before battle is resolved. Opponent may protect leader with a
@@ -50,6 +54,7 @@ const card_text = {
   ),
   Snooper: (
     <>
+      <p className="heading">Poison defense</p>
       {BattlePlan}
       <p>Protects your leader from a poison weapon in this battle.</p>
       {WinnerKeeps}
@@ -57,6 +62,7 @@ const card_text = {
   ),
   Shield: (
     <>
+      <p className="heading">Projectile defense</p>
       {BattlePlan}
       <p>Protects your leader from a projectile weapon in this battle.</p>
       {WinnerKeeps}
@@ -64,6 +70,7 @@ const card_text = {
   ),
   "Family Atomics": (
     <>
+      {Special}
       <p>
         After the first game turn, play after the storm movement is calculated, but before the storm
         is moved, <b>but only</b> if you have one more forces on the Shield Wall or a territory
@@ -80,6 +87,7 @@ const card_text = {
   ),
   "Weather Control": (
     <>
+      {Special}
       <p>
         After the first game turn, play during the Storm Phase, before the Storm Marker is moved.
       </p>
@@ -91,6 +99,7 @@ const card_text = {
   ),
   Hajr: (
     <>
+      {Special}
       <p>Play during Movement Phase.</p>
       <p>Make an extra on-planet force movement subject to normal movement rules.</p>
       <p>The forces you move may be a group you've already moved this phase or another group.</p>
@@ -98,6 +107,7 @@ const card_text = {
   ),
   "Cheap Hero": (
     <>
+      {Special}
       <p>Play as a leader with zero strength on your Battle Plan and discard after the battle.</p>
       <p>
         You may also play a weapon and a defense. The cheap hero may be played in place of a leader
@@ -107,6 +117,7 @@ const card_text = {
   ),
   Karama: (
     <>
+      {Special}
       <p>
         After factions complete their "At Start" actions and after game set-up, use this card to
         stop a player from using one of their faction advantages when they attempt to use it. Stops
@@ -125,6 +136,7 @@ const card_text = {
   ),
   "Tleilaxu Ghola": (
     <>
+      {Special}
       <p>Play at any time to gain an extra revival.</p>
       <p>
         You may immediately revive 1 of your leaders regardless of how many leaders you have in the
@@ -136,6 +148,7 @@ const card_text = {
   ),
   Truthtrance: (
     <>
+      {Special}
       <p>
         Publicly ask one other player a single yes/no question about the game that must be answered
         publicly. The game pauses until an answer is given.

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -6,6 +6,17 @@ import { treachery_card_t } from "ts/treachery_card";
 export const close_modal = createAction("view/none");
 export const show_add_cards_modal = createAction<house_name_t>("view/add_card");
 export const show_reset_game_modal = createAction("view/reset");
+export const show_discard_unknown_modal = createAction(
+  "view/discard_unknown",
+  (house: house_name_t, unknown_card_index: number) => {
+    return {
+      payload: {
+        house,
+        unknown_card_index,
+      },
+    };
+  }
+);
 
 export const house_add_card = createAction(
   "houses/add_card",
@@ -27,6 +38,21 @@ export const house_remove_card = createAction(
         house,
         index,
         card,
+      },
+    };
+  }
+);
+
+export const house_add_unknown = createAction<house_name_t>("houses/add_unknown");
+
+export const house_remove_unknown = createAction(
+  "houses/remove_unknown",
+  (house: house_name_t, unknown_index: number, actual_card_id: string) => {
+    return {
+      payload: {
+        house,
+        unknown_index,
+        actual_card_id,
       },
     };
   }
@@ -57,3 +83,4 @@ export const house_toggle_expand_cards = createAction(
 
 export const start_game = createAction<start_game_spec>("game/start");
 export const reset_game = createAction("game/reset");
+export const undo_action = createAction("game/undo");

--- a/src/ts/state/initial_card_pool.ts
+++ b/src/ts/state/initial_card_pool.ts
@@ -1,105 +1,170 @@
 import { treachery_card_t } from "ts/treachery_card";
 
-const initial_card_pool: ReadonlyArray<{ card: treachery_card_t; num?: number }> = [
+const initial_deck: ReadonlyArray<treachery_card_t> = [
   {
-    card: {
-      kind: "Weapon",
-      type: "Poison",
-    },
-    num: 4,
+    id: "Chaumas",
+    kind: "Weapon",
+    type: "Poison",
   },
   {
-    card: {
-      kind: "Weapon",
-      type: "Projectile",
-    },
-    num: 4,
+    id: "Chaumurky",
+    kind: "Weapon",
+    type: "Poison",
   },
   {
-    card: {
-      kind: "Weapon",
-      type: "Lasgun",
-    },
-    num: 1,
-  },
-
-  {
-    card: {
-      kind: "Defense",
-      type: "Shield",
-    },
-    num: 4,
+    id: "Gom Jabbar",
+    kind: "Weapon",
+    type: "Poison",
   },
   {
-    card: {
-      kind: "Defense",
-      type: "Snooper",
-    },
-    num: 4,
-  },
-
-  {
-    card: {
-      kind: "Special",
-      type: "Cheap Hero",
-    },
-    num: 3,
+    id: "Kriminon",
+    kind: "Weapon",
+    type: "Poison",
   },
   {
-    card: {
-      kind: "Special",
-      type: "Karama",
-    },
-    num: 2,
+    id: "Slip-Tip",
+    kind: "Weapon",
+    type: "Projectile",
   },
   {
-    card: {
-      kind: "Special",
-      type: "Truthtrance",
-    },
-    num: 2,
+    id: "Slip-Tip",
+    kind: "Weapon",
+    type: "Projectile",
   },
   {
-    card: {
-      kind: "Special",
-      type: "Family Atomics",
-    },
-    num: 1,
+    id: "Maula Pistol",
+    kind: "Weapon",
+    type: "Projectile",
   },
   {
-    card: {
-      kind: "Special",
-      type: "Hajr",
-    },
-    num: 1,
+    id: "Chrysknife",
+    kind: "Weapon",
+    type: "Projectile",
   },
   {
-    card: {
-      kind: "Special",
-      type: "Tleilaxu Ghola",
-    },
-    num: 1,
-  },
-  {
-    card: {
-      kind: "Special",
-      type: "Weather Control",
-    },
-    num: 1,
+    id: "Lasgun",
+    kind: "Weapon",
+    type: "Lasgun",
   },
 
   {
-    card: {
-      kind: "Useless",
-    },
-    num: 5,
+    id: "shield_1",
+    kind: "Defense",
+    type: "Shield",
+  },
+  {
+    id: "shield_2",
+    kind: "Defense",
+    type: "Shield",
+  },
+  {
+    id: "shield_3",
+    kind: "Defense",
+    type: "Shield",
+  },
+  {
+    id: "shield_4",
+    kind: "Defense",
+    type: "Shield",
   },
 
   {
-    card: {
-      kind: "Unknown",
-    },
+    id: "snooper_1",
+    kind: "Defense",
+    type: "Snooper",
+  },
+  {
+    id: "snooper_2",
+    kind: "Defense",
+    type: "Snooper",
+  },
+  {
+    id: "snooper_3",
+    kind: "Defense",
+    type: "Snooper",
+  },
+  {
+    id: "snooper_4",
+    kind: "Defense",
+    type: "Snooper",
+  },
+
+  {
+    id: "cheap hero 1",
+    kind: "Special",
+    type: "Cheap Hero",
+  },
+  {
+    id: "cheap hero 2",
+    kind: "Special",
+    type: "Cheap Hero",
+  },
+  {
+    id: "cheap hero 3",
+    kind: "Special",
+    type: "Cheap Hero",
+  },
+  {
+    id: "karama 1",
+    kind: "Special",
+    type: "Karama",
+  },
+  {
+    id: "karama 2",
+    kind: "Special",
+    type: "Karama",
+  },
+  {
+    id: "truthtrance 1",
+    kind: "Special",
+    type: "Truthtrance",
+  },
+  {
+    id: "truthtrance 2",
+    kind: "Special",
+    type: "Truthtrance",
+  },
+  {
+    id: "family atomics",
+    kind: "Special",
+    type: "Family Atomics",
+  },
+  {
+    id: "hajr",
+    kind: "Special",
+    type: "Hajr",
+  },
+  {
+    id: "tleilaxu ghola",
+    kind: "Special",
+    type: "Tleilaxu Ghola",
+  },
+  {
+    id: "weather control",
+    kind: "Special",
+    type: "Weather Control",
+  },
+
+  {
+    id: "Baliset",
+    kind: "Useless",
+  },
+  {
+    id: "Jubba Cloak",
+    kind: "Useless",
+  },
+  {
+    id: "Kulon",
+    kind: "Useless",
+  },
+  {
+    id: "La La La",
+    kind: "Useless",
+  },
+  {
+    id: "Trip to Gamont",
+    kind: "Useless",
   },
 ] as const;
 
-export default initial_card_pool;
+export default initial_deck;

--- a/src/ts/state/initial_deck.ts
+++ b/src/ts/state/initial_deck.ts
@@ -1,6 +1,6 @@
 import { treachery_card_t } from "ts/treachery_card";
 
-const initial_deck: ReadonlyArray<treachery_card_t> = [
+const initial_deck: Array<treachery_card_t> = [
   {
     id: "Chaumas",
     kind: "Weapon",
@@ -27,7 +27,7 @@ const initial_deck: ReadonlyArray<treachery_card_t> = [
     type: "Projectile",
   },
   {
-    id: "Slip-Tip",
+    id: "Stunner",
     kind: "Weapon",
     type: "Projectile",
   },
@@ -165,6 +165,6 @@ const initial_deck: ReadonlyArray<treachery_card_t> = [
     id: "Trip to Gamont",
     kind: "Useless",
   },
-] as const;
+];
 
 export default initial_deck;

--- a/src/ts/state/reducers.ts
+++ b/src/ts/state/reducers.ts
@@ -9,11 +9,15 @@ import {
   close_modal,
   house_set_ally,
   house_toggle_expand_cards,
+  house_add_unknown,
+  house_remove_unknown,
+  show_discard_unknown_modal,
+  undo_action,
 } from "ts/state/actions";
 import { ENEMY_HOUSE_NAMES, house_name_t } from "ts/houses";
-import { houses_state_t, view_state_t, game_state_t } from "ts/state/types";
-import { list_priorities, treachery_card_t } from "ts/treachery_card";
-import initial_card_pool from "ts/state/initial_card_pool";
+import { houses_state_t, view_state_t, game_state_t, game_history_t } from "ts/state/types";
+import { card_sort } from "ts/treachery_card";
+import initial_deck from "ts/state/initial_deck";
 
 export const initial_houses_state: houses_state_t = {
   Atreides: {
@@ -22,98 +26,216 @@ export const initial_houses_state: houses_state_t = {
     cards: [],
     name: "Atreides",
     show_cards: false,
+    unknown_cards: [],
   },
   "Bene Gesserit": {
     active: false,
     ally: null,
-    cards: [{ kind: "Unknown" }],
+    cards: [],
     name: "Bene Gesserit",
     show_cards: false,
+    unknown_cards: [{ deck_index: 0 }],
   },
   Emperor: {
     active: false,
     ally: null,
-    cards: [{ kind: "Unknown" }],
+    cards: [],
     name: "Emperor",
     show_cards: false,
+    unknown_cards: [{ deck_index: 0 }],
   },
   Fremen: {
     active: false,
     ally: null,
-    cards: [{ kind: "Unknown" }],
+    cards: [],
     name: "Fremen",
     show_cards: false,
+    unknown_cards: [{ deck_index: 0 }],
   },
   Harkonnen: {
     active: false,
     ally: null,
-    cards: [{ kind: "Unknown" }, { kind: "Unknown" }],
+    cards: [],
     name: "Harkonnen",
     show_cards: false,
+    unknown_cards: [{ deck_index: 0 }, { deck_index: 0 }],
   },
   "Spacing Guild": {
     active: false,
     ally: null,
-    cards: [{ kind: "Unknown" }],
+    cards: [],
     name: "Spacing Guild",
     show_cards: false,
+    unknown_cards: [{ deck_index: 0 }],
   },
 };
 
-export const house_state_reducer = createReducer(initial_houses_state, builder => {
-  function getHouse(name: house_name_t, state: houses_state_t) {
-    const house = state[name];
-    if (!house.active) {
-      throw new Error("House " + name + " not present in this game");
-    }
-    return house;
+export const initial_game_state: game_state_t = {
+  initialized: false,
+  history: [],
+  current: {
+    decks: [
+      { cards: [...initial_deck], num_unknowns: 0 },
+      { cards: [], num_unknowns: 0 }, // and initialize a discard deck ready
+    ],
+    houses: initial_houses_state,
+    draw_deck_index: 0,
+  },
+};
+
+function clone_history(snapshot: game_history_t): game_history_t {
+  return JSON.parse(JSON.stringify(snapshot));
+}
+
+function push_history(state: game_state_t, handler: (state: game_history_t) => void): game_state_t {
+  const current = clone_history(state.current);
+  handler(current);
+  let history = [...state.history];
+  if (history.length === 50) {
+    // if the history length is too long, remove the oldest entry
+    history.pop();
   }
+  const new_state = {
+    ...state,
+    current,
+    history: [state.current, ...history],
+  };
+  return new_state;
+}
+
+function getHouse(name: house_name_t, state: houses_state_t) {
+  const house = state[name];
+  if (!house.active) {
+    throw new Error("House " + name + " not present in this game");
+  }
+  return house;
+}
+
+export const game_state_reducer = createReducer(initial_game_state, builder => {
+  builder.addCase(undo_action, state => {
+    if (state.history.length === 0) {
+      return state;
+    } else {
+      const [previous, ...rest] = state.history;
+      return {
+        ...state,
+        current: previous,
+        history: rest,
+      };
+    }
+  });
 
   builder.addCase(house_add_card, (state, action) => {
-    let house = getHouse(action.payload.house, state);
-    house.cards.push(action.payload.card);
-    house.cards.sort((a, b) => list_priorities[a.kind] - list_priorities[b.kind]);
+    return push_history(state, next => {
+      let house = getHouse(action.payload.house, next.houses);
+      house.cards.push(action.payload.card);
+      house.cards.sort(card_sort);
+
+      const deck = next.decks[next.draw_deck_index];
+      deck.cards.splice(
+        deck.cards.findIndex(c => c.id === action.payload.card.id),
+        1
+      );
+
+      if (deck.cards.length - deck.num_unknowns === 0) {
+        // We've exhausted this deck. Increment draw deck, and add a new discard deck if necessary
+        next.draw_deck_index += 1;
+        if (next.decks.length === next.draw_deck_index) {
+          next.decks.push({ cards: [], num_unknowns: 0 });
+        }
+      }
+    });
   });
 
   builder.addCase(house_remove_card, (state, action) => {
-    let house = getHouse(action.payload.house, state);
-    house.cards.splice(action.payload.index, 1);
+    return push_history(state, history => {
+      let house = getHouse(action.payload.house, history.houses);
+      const [removed_card] = house.cards.splice(action.payload.index, 1);
+      const discard_deck = history.decks[history.decks.length - 1];
+      discard_deck.cards.push(removed_card);
+      discard_deck.cards.sort(card_sort);
+    });
+  });
+
+  builder.addCase(house_add_unknown, (state, action) => {
+    return push_history(state, history => {
+      let house = getHouse(action.payload, history.houses);
+      house.unknown_cards.push({ deck_index: history.draw_deck_index });
+
+      const deck = history.decks[history.draw_deck_index];
+      deck.num_unknowns += 1;
+
+      if (deck.cards.length - deck.num_unknowns === 0) {
+        // We've exhausted this deck. Increment draw deck, and add a new discard deck if necessary
+        history.draw_deck_index += 1;
+        if (history.decks.length === history.draw_deck_index) {
+          history.decks.push({ cards: [], num_unknowns: 0 });
+        }
+      }
+    });
+  });
+
+  builder.addCase(house_remove_unknown, (state, action) => {
+    return push_history(state, history => {
+      let house = getHouse(action.payload.house, history.houses);
+      const [unknown_card] = house.unknown_cards.splice(action.payload.unknown_index);
+      const deck = history.decks[unknown_card.deck_index];
+      const [card] = deck.cards.splice(
+        deck.cards.findIndex(c => c.id === action.payload.actual_card_id),
+        1
+      );
+
+      deck.num_unknowns -= 1;
+      // push this card into the current discard pile
+      const discard_deck = history.decks[history.decks.length - 1];
+      discard_deck.cards.push(card);
+      discard_deck.cards.sort(card_sort);
+    });
   });
 
   builder.addCase(house_set_ally, (state, action) => {
-    if (action.payload.house === action.payload.ally) {
-      throw new Error("Cannot ally to self!");
-    }
-
-    let house = getHouse(action.payload.house, state);
-    if (house.ally && house.ally !== action.payload.ally) {
-      state[house.ally].ally = null;
-    }
-    house.ally = action.payload.ally;
-    if (house.ally) {
-      const old_ally = state[house.ally].ally;
-      state[house.ally].ally = house.name;
-      if (old_ally) {
-        state[old_ally].ally = null;
+    return push_history(state, history => {
+      if (action.payload.house === action.payload.ally) {
+        throw new Error("Cannot ally to self!");
       }
-    }
+
+      let house = getHouse(action.payload.house, history.houses);
+      if (house.ally && house.ally !== action.payload.ally) {
+        history.houses[house.ally].ally = null;
+      }
+      house.ally = action.payload.ally;
+      if (house.ally) {
+        const old_ally = history.houses[house.ally].ally;
+        history.houses[house.ally].ally = house.name;
+        if (old_ally) {
+          history.houses[old_ally].ally = null;
+        }
+      }
+    });
   });
 
   builder.addCase(house_toggle_expand_cards, (state, action) => {
-    let house = getHouse(action.payload.house, state);
+    let house = getHouse(action.payload.house, state.current.houses);
     house.show_cards = !house.show_cards;
   });
 
   builder.addCase(reset_game, _ => {
-    return initial_houses_state;
+    return initial_game_state;
   });
 
   builder.addCase(start_game, (state, action) => {
+    const history = state.current;
     for (let house of ENEMY_HOUSE_NAMES) {
       if (action.payload[house]) {
-        state[house].active = true;
+        history.houses[house].active = true;
+        for (var i = 0; i < history.houses[house].unknown_cards.length; i++) {
+          history.decks[0].num_unknowns += 1;
+        }
       }
     }
+
+    state.initialized = true;
+    state.current.decks[state.current.draw_deck_index].cards.sort(card_sort);
   });
 });
 
@@ -124,69 +246,26 @@ export const default_view_state: view_state_t = {
 
 export const view_state_reducer = createReducer(default_view_state, builder => {
   builder.addCase(close_modal, (state, _) => {
-    state.active_modal = "overview";
-    state.house_name = undefined;
+    return default_view_state;
   });
 
   builder.addCase(show_add_cards_modal, (state, action) => {
-    state.active_modal = "add_card";
-    state.house_name = action.payload;
+    return { ...default_view_state, house_name: action.payload, active_modal: "add_card" };
   });
 
   builder.addCase(show_reset_game_modal, state => {
-    state.active_modal = "reset_game";
-    state.house_name = undefined;
-  });
-});
-
-export const default_game_state: game_state_t = {
-  initialized: false,
-  treachery_card_pool: initial_card_pool,
-};
-
-export const game_state_reducer = createReducer(default_game_state, builder => {
-  builder.addCase(start_game, (state, action) => {
-    state.initialized = true;
+    return { ...default_view_state, active_modal: "reset_game" };
   });
 
-  builder.addCase(reset_game, (state, action) => {
-    return default_game_state;
-  });
-
-  builder.addCase(house_add_card, (state, action) => {
-    const index = state.treachery_card_pool.findIndex(e => sameCard(action.payload.card, e.card));
-    if (index !== -1) {
-      const entry = state.treachery_card_pool[index];
-      if (entry.num !== undefined && entry.num > 0) {
-        entry.num -= 1;
-      }
-      state.treachery_card_pool[index] = entry;
-    }
-  });
-
-  builder.addCase(house_remove_card, (state, action) => {
-    const index = state.treachery_card_pool.findIndex(e => sameCard(action.payload.card, e.card));
-    if (index !== -1) {
-      const entry = state.treachery_card_pool[index];
-      if (entry.num !== undefined) {
-        entry.num += 1;
-      }
-      state.treachery_card_pool[index] = entry;
-    }
+  builder.addCase(show_discard_unknown_modal, (state, action) => {
+    state.active_modal = "discard_unknown";
+    state.house_name = action.payload.house;
   });
 });
 
 export const root_reducer = combineReducers({
-  houses: house_state_reducer,
   view: view_state_reducer,
   game: game_state_reducer,
 });
 
-export type root_state = ReturnType<typeof root_reducer>;
-
-function sameCard(a: treachery_card_t, b: treachery_card_t): boolean {
-  if (a.kind !== b.kind) {
-    return false;
-  }
-  return (a as any).type === (b as any).type;
-}
+export type root_state_t = ReturnType<typeof root_reducer>;

--- a/src/ts/state/store.ts
+++ b/src/ts/state/store.ts
@@ -1,5 +1,5 @@
 import { createStore } from "redux";
-import { root_reducer, root_state } from "./reducers";
+import { root_reducer, root_state_t } from "./reducers";
 
 import { createMigrate, persistStore, persistReducer } from "redux-persist";
 import storage from "redux-persist/lib/storage";
@@ -12,6 +12,12 @@ const migrations = {
   1: (state: any) => {
     return { ...state, houses: undefined };
   },
+  2: (state: any) => {
+    return { ...state, game: undefined };
+  },
+  3: (state: any) => {
+    return undefined;
+  },
 };
 
 const persistConfig = {
@@ -19,10 +25,10 @@ const persistConfig = {
   storage: storage,
   stateReconciler: autoMergeLevel2,
   migrate: createMigrate(migrations),
-  version: 1,
+  version: 3,
 };
 
-const pReducer = persistReducer<root_state>(persistConfig, root_reducer);
+const pReducer = persistReducer<root_state_t>(persistConfig, root_reducer);
 
 export const store = createStore(pReducer);
 export const persistor = persistStore(store);

--- a/src/ts/state/types.ts
+++ b/src/ts/state/types.ts
@@ -1,6 +1,5 @@
 import { enemy_house_name_t, house_name_t } from "../houses";
-import cardPool from "ts/state/initial_card_pool";
-import { treachery_card_t } from "ts/treachery_card";
+import { treachery_card_t, unknown_card_t } from "ts/treachery_card";
 
 export type start_game_spec = {
   [key in enemy_house_name_t]: boolean;
@@ -8,6 +7,7 @@ export type start_game_spec = {
 
 export interface house_state_t {
   cards: Array<treachery_card_t>;
+  unknown_cards: Array<unknown_card_t>;
   name: house_name_t;
   ally: house_name_t | null;
   active: boolean;
@@ -18,14 +18,30 @@ export type houses_state_t = {
   [key in house_name_t]: house_state_t;
 };
 
-export type active_page = "overview" | "add_card" | "reset_game" | "alliance";
+export type active_page = "overview" | "add_card" | "discard_unknown" | "reset_game" | "alliance";
 
 export interface view_state_t {
   active_modal: active_page;
   house_name?: house_name_t;
 }
 
+export interface deck_t {
+  cards: Array<treachery_card_t>;
+  num_unknowns: number;
+}
+
+export interface game_history_t {
+  decks: Array<deck_t>;
+  houses: houses_state_t;
+  draw_deck_index: number;
+}
+
 export interface game_state_t {
   initialized: boolean;
-  treachery_card_pool: typeof cardPool;
+  history: Array<game_history_t>;
+  current: game_history_t;
+  // keep a record of every change the player makes, so they can revert any action.
+  // Set an arbitary limit like 50 moves or something.
+  // last entry is the most recent
+  // ordered from newest to oldest. So history[0] is state before current.
 }

--- a/src/ts/treachery_card.ts
+++ b/src/ts/treachery_card.ts
@@ -1,18 +1,22 @@
 export interface weapon_card {
+  id: string;
   kind: "Weapon";
   type: "Projectile" | "Poison" | "Lasgun";
 }
 
 export interface defence_card {
+  id: string;
   kind: "Defense";
   type: "Shield" | "Snooper";
 }
 
 export interface useless_card {
+  id: string;
   kind: "Useless";
 }
 
 export interface special_card {
+  id: string;
   kind: "Special";
   type:
     | "Truthtrance"
@@ -25,7 +29,7 @@ export interface special_card {
 }
 
 export interface unknown_card {
-  kind: "Unknown";
+  deck_id: number;
 }
 
 export type treachery_card_t =
@@ -33,16 +37,10 @@ export type treachery_card_t =
   | defence_card
   | useless_card
   | special_card
-  | unknown_card;
-export type treachery_card_kind = treachery_card_t["kind"];
-export type special_card_type = special_card["type"];
-export type weapon_card_type = weapon_card["type"];
-export type defence_card_type = defence_card["type"];
 
-export const list_priorities: { [key in treachery_card_kind]: number } = {
+export const list_priorities: { [key in treachery_card_t["kind"]]: number } = {
   Weapon: 0,
   Defense: 1,
   Special: 2,
   Useless: 3,
-  Unknown: 4,
 };

--- a/src/ts/treachery_card.ts
+++ b/src/ts/treachery_card.ts
@@ -28,19 +28,27 @@ export interface special_card {
     | "Family Atomics";
 }
 
-export interface unknown_card {
-  deck_id: number;
+export interface unknown_card_t {
+  deck_index: number;
 }
 
-export type treachery_card_t =
-  | weapon_card
-  | defence_card
-  | useless_card
-  | special_card
+export type treachery_card_t = weapon_card | defence_card | useless_card | special_card;
 
-export const list_priorities: { [key in treachery_card_t["kind"]]: number } = {
+const list_priorities: { [key in treachery_card_t["kind"]]: number } = {
   Weapon: 0,
   Defense: 1,
   Special: 2,
   Useless: 3,
 };
+
+export function card_sort(a: treachery_card_t, b: treachery_card_t): number {
+  if (a.kind !== b.kind) {
+    return list_priorities[a.kind] - list_priorities[b.kind];
+  }
+  let anyA: any = a;
+  let anyB: any = b;
+  if (anyA.type !== anyB.type) {
+    return anyA.type.localeCompare(anyB.type);
+  }
+  return a.id.localeCompare(b.id);
+}


### PR DESCRIPTION
Create card object for every in-game card.
Keep track of the opening deck. Assigning a player an unknown card will now keep track of the pool of potential cards that card was assigned from. When the deck is exhausted, the potentials and the number of unknowns associated with them are still tracked, so you always get accurate information.

Also rework some of the UI around displaying cards, and add an undo feature - the games history is tracked for 50 previous actions. This means I can do away with many of the modals to confirm actions - as if you did something by accident you can just undo it.
